### PR TITLE
feat: Add GitHub Actions CI workflow for automated APK builds

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,0 +1,44 @@
+name: Android CI Build APK
+
+on:
+  push:
+    branches:
+      - main # Or 'master' if that's your primary branch
+
+jobs:
+  build:
+    name: Build Release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin' # Popular distribution
+
+      - name: Setup Gradle and cache
+        uses: gradle/actions/setup-gradle@v3 # Combined setup and caching
+        with:
+          # gradle-version: wrapper # Use the wrapper defined in the project
+          # cache-read-only: ${{ github.ref != 'refs/heads/main' }} # Example: only write to cache on main branch pushes
+          # Arguments for setup-gradle can be further customized if needed
+          # For example, to specify build-root-directory if your Gradle project is not at the root:
+          build-root-directory: SMSBackupToDrive
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x SMSBackupToDrive/gradlew
+        # Working directory is the root of the repo by default
+
+      - name: Build with Gradle (Package Release APK)
+        # Use packageReleaseApk to get the versioned APK in the apks/ directory
+        run: ./SMSBackupToDrive/gradlew -p SMSBackupToDrive :app:packageReleaseApk
+
+      - name: Upload Release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: sms-backup-apk # Name of the artifact bundle
+          path: apks/sms_backup_to_drive_v*.apk # Path to the versioned APK in the apks directory
+          # retention-days: 5 # Optional: how long to keep the artifact

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ A helper script is provided to automate the building of the APK and committing i
     - Commit the APK with a message like "feat: Build and add release APK vX.Y (YYYY-MM-DD HH:MM UTC)".
     - It will remind you to `git push` the changes if desired.
 
+### Automated Builds via GitHub Actions
+This project uses GitHub Actions to automatically build the release APK whenever changes are pushed to the `main` branch. The generated APK is available as a downloadable artifact from the workflow run in the 'Actions' tab of the GitHub repository.
+
 ## Development Notes
 - The application uses Google Sign-In for authentication and requires appropriate OAuth 2.0 credentials (client ID) to be configured in `strings.xml` (`server_client_id`) for the Google Sign-In and Google Sheets/Drive API access to work.
 - SMS messages are stored in a Google Sheet named "SMS Backups" in the user's Google Drive.


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the build process for the Android application.

Key changes:
- Created `.github/workflows/android_build.yml`:
  - Triggers on pushes to the `main` branch.
  - Checks out code, sets up JDK 17, and configures Gradle with caching.
  - Runs the `./SMSBackupToDrive/gradlew :app:packageReleaseApk` task to build the versioned release APK and place it in the `apks/` directory.
  - Uploads the versioned APK from the `apks/` directory as a workflow artifact named `sms-backup-apk`.
- Updated `README.md`:
  - Added a section detailing the automated build process via GitHub Actions, explaining that APKs are available as artifacts from workflow runs.

This CI setup will help ensure that a buildable APK is always available and provides a basis for further automation like releases.